### PR TITLE
Add LegacyExtension attachMappings patch

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/legacy/FormatSRG.java
+++ b/src/common/java/net/minecraftforge/gradle/common/legacy/FormatSRG.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.gradle.common.legacy;
+
+import net.minecraftforge.srgutils.IMappingFile;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+
+public abstract class FormatSRG extends DefaultTask {
+    private final Property<IMappingFile.Format> format;
+
+    public FormatSRG() {
+        this.format = getProject().getObjects().property(IMappingFile.Format.class)
+                .convention(IMappingFile.Format.SRG);
+        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(f -> f.file("output.srg")));
+    }
+
+    @TaskAction
+    public void apply() throws IOException {
+        IMappingFile input = IMappingFile.load(getSrg().get().getAsFile());
+        input.write(getOutput().get().getAsFile().toPath(), getFormat().get(), false);
+    }
+
+    @InputFile
+    public abstract RegularFileProperty getSrg();
+
+    @Input
+    public Property<IMappingFile.Format> getFormat() {
+        return this.format;
+    }
+
+    public void setFormat(String value) {
+        this.getFormat().set(IMappingFile.Format.valueOf(value));
+    }
+
+    @OutputFile
+    public abstract RegularFileProperty getOutput();
+}

--- a/src/common/java/net/minecraftforge/gradle/common/legacy/LegacyExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/legacy/LegacyExtension.java
@@ -9,6 +9,7 @@ import groovy.lang.GroovyObjectSupport;
 import net.minecraftforge.gradle.common.tasks.ExtractMCPData;
 import net.minecraftforge.gradle.common.tasks.ExtractZip;
 import net.minecraftforge.gradle.common.util.MinecraftExtension;
+import net.minecraftforge.srgutils.IMappingFile;
 import net.minecraftforge.srgutils.MinecraftVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -110,10 +111,21 @@ public abstract class LegacyExtension extends GroovyObjectSupport {
             project.getLogger().info("LegacyExtension: Attaching mappings path to runs");
             // Get the existing extractSrg task
             final TaskProvider<ExtractMCPData> extractSrg = project.getTasks().named("extractSrg", ExtractMCPData.class);
+            // Convert the mappings file to the desired format
+            final TaskProvider<FormatSRG> attachMappingsTask = project.getTasks().register("attachMappings", FormatSRG.class, t -> {
+                t.dependsOn(extractSrg);
+                // Set the input SRG to the extract task's output
+                t.getSrg().set(extractSrg.flatMap(ExtractMCPData::getOutput));
+                // Mods expect the classic SRG format
+                t.getFormat().set(IMappingFile.Format.SRG);
+            });
             // Get the task's output file as a provider
-            final Provider<File> mappingsFile = extractSrg.flatMap(t -> t.getOutput().getAsFile());
+            final Provider<File> mappingsFile = attachMappingsTask.flatMap(t -> t.getOutput().getAsFile());
             // Attach the property along with the file path to each run configuration 
             minecraft.getRuns().configureEach(run -> run.property("net.minecraftforge.gradle.GradleStart.srg.notch-srg", mappingsFile.get()));
+
+            // execute attachMappings before each run task
+            project.getTasks().named("prepareRuns").configure(t -> t.dependsOn(attachMappingsTask));
         }
     }
 

--- a/src/common/java/net/minecraftforge/gradle/common/legacy/LegacyExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/legacy/LegacyExtension.java
@@ -112,20 +112,19 @@ public abstract class LegacyExtension extends GroovyObjectSupport {
             // Get the existing extractSrg task
             final TaskProvider<ExtractMCPData> extractSrg = project.getTasks().named("extractSrg", ExtractMCPData.class);
             // Convert the mappings file to the desired format
-            final TaskProvider<FormatSRG> attachMappingsTask = project.getTasks().register("attachMappings", FormatSRG.class, t -> {
-                t.dependsOn(extractSrg);
+            final TaskProvider<FormatSRG> createLegacyObf2Srg = project.getTasks().register("createLegacyObf2Srg", FormatSRG.class, t -> {
                 // Set the input SRG to the extract task's output
                 t.getSrg().set(extractSrg.flatMap(ExtractMCPData::getOutput));
                 // Mods expect the classic SRG format
                 t.getFormat().set(IMappingFile.Format.SRG);
             });
             // Get the task's output file as a provider
-            final Provider<File> mappingsFile = attachMappingsTask.flatMap(t -> t.getOutput().getAsFile());
+            final Provider<File> mappingsFile = createLegacyObf2Srg.flatMap(t -> t.getOutput().getAsFile());
             // Attach the property along with the file path to each run configuration 
             minecraft.getRuns().configureEach(run -> run.property("net.minecraftforge.gradle.GradleStart.srg.notch-srg", mappingsFile.get()));
 
             // execute attachMappings before each run task
-            project.getTasks().named("prepareRuns").configure(t -> t.dependsOn(attachMappingsTask));
+            project.getTasks().named("prepareRuns").configure(t -> t.dependsOn(createLegacyObf2Srg));
         }
     }
 


### PR DESCRIPTION
Adds a LegacyExtension patch to attach the FG2 srg mappings property to run configurations.

FG2 GradleStart exposes a <code>net.minecraftforge.gradle.GradleStart.srg.notch-srg</code> property that points to a NOTCH -> SRG mapping file. This can be consumed by mods to access obfuscation mappings at runtime. We replicate the FG2 behavior by attaching the property to each run configuration and pointing it to the output of the extractSrg task, which is the srg mapping file extracted from mcp config.

Tested in a RetroGradle MinecraftForge revision [2b442cc](https://github.com/RetroGradle/MinecraftForge/tree/2b442cc0e433e8b893fb5b9b2beeae20394c1745) userdev environment by running [CodeChickenLib](https://www.curseforge.com/minecraft/mc-mods/codechicken-lib-1-8), a mod that requires this property to function.